### PR TITLE
Implement more of the exception tests

### DIFF
--- a/litmus/litmus_tests/exc/LB+R-svc-W+R-svc-W.c
+++ b/litmus/litmus_tests/exc/LB+R-svc-W+R-svc-W.c
@@ -23,7 +23,6 @@ static void P0(litmus_test_run* data) {
       "svc #0\n\t"
       /* extract values */
       "str x0, [%[outp0r0]]\n\t"
-      "dmb st\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)
@@ -48,7 +47,6 @@ static void P1(litmus_test_run* data) {
       "ldr x0, [x1]\n\t"
       "svc #0\n\t"
       "str x0, [%[outp1r0]]\n\t"
-      "dmb st\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)

--- a/litmus/litmus_tests/exc/LB+R-svc-W+R-svc-W.c
+++ b/litmus/litmus_tests/exc/LB+R-svc-W+R-svc-W.c
@@ -21,6 +21,7 @@ static void P0(litmus_test_run* data) {
 
       "ldr x0, [x1]\n\t"
       "svc #0\n\t"
+
       /* extract values */
       "str x0, [%[outp0r0]]\n\t"
   :
@@ -44,8 +45,11 @@ static void P1(litmus_test_run* data) {
       "mov x1, %[y]\n\t"
       "mov x3, %[x]\n\t"
 
+      /* test */
       "ldr x0, [x1]\n\t"
       "svc #0\n\t"
+
+      /* extract values */
       "str x0, [%[outp1r0]]\n\t"
   :
   : ASM_VARS(data, VARS),

--- a/litmus/litmus_tests/exc/LB+R-svc-W+R-svc-W.c
+++ b/litmus/litmus_tests/exc/LB+R-svc-W+R-svc-W.c
@@ -78,4 +78,5 @@ litmus_test_t LB_RsvcW_RsvcW = {
       /* p0:x2 =*/1,
       /* p1:x2 =*/1,
   },
+  .no_sc_results = 3,
 };

--- a/litmus/litmus_tests/exc/LB+svc-dmb-erets.c
+++ b/litmus/litmus_tests/exc/LB+svc-dmb-erets.c
@@ -1,0 +1,86 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p0x0, p1x0
+
+static void svc_handler0(void) {
+  asm volatile(
+      "dmb sy\n\t"
+      "eret\n\t");
+}
+
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+    /*initial registers */
+      "mov x2, #1\n\t"
+      "mov x1, %[x]\n\t"
+      "mov x3, %[y]\n\t"
+
+      /* test */
+      "ldr x0, [x1]\n\t"
+      "svc #0\n\t"
+      /* x3 = Y */
+      "str x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp0r0]]\n\t"
+      "dmb st\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3"
+  );
+}
+
+static void svc_handler1(void) {
+  asm volatile(
+      /* x3 = X */
+      "ldr x0, [x1]\n\t"
+      "eret\n\t");
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* initial registers */
+      "mov x2, #1\n\t"
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* test */
+      "svc #0\n\t"
+      "str x2, [x3]\n\t"
+
+      /* extract values  */
+      "str x0, [%[outp1r0]]\n\t"
+      "dmb st\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+
+
+litmus_test_t LB_svcdmberets = {
+  "LB+svc-dmb-erets",
+  MAKE_THREADS(2),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+     (u32*[]){(u32*)svc_handler0, NULL},
+     (u32*[]){(u32*)svc_handler1, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p0:x2 =*/1,
+      /* p1:x2 =*/1,
+  },
+};

--- a/litmus/litmus_tests/exc/LB+svc-dmb-erets.c
+++ b/litmus/litmus_tests/exc/LB+svc-dmb-erets.c
@@ -25,7 +25,6 @@ static void P0(litmus_test_run* data) {
 
       /* extract values */
       "str x0, [%[outp0r0]]\n\t"
-      "dmb st\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)
@@ -54,7 +53,6 @@ static void P1(litmus_test_run* data) {
 
       /* extract values  */
       "str x0, [%[outp1r0]]\n\t"
-      "dmb st\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)

--- a/litmus/litmus_tests/exc/LB+svc-dmb-erets.c
+++ b/litmus/litmus_tests/exc/LB+svc-dmb-erets.c
@@ -84,4 +84,5 @@ litmus_test_t LB_svcdmberets = {
       /* p0:x2 =*/1,
       /* p1:x2 =*/1,
   },
+  .no_sc_results = 3,
 };

--- a/litmus/litmus_tests/exc/LB+svc-dmb-erets.c
+++ b/litmus/litmus_tests/exc/LB+svc-dmb-erets.c
@@ -35,8 +35,7 @@ static void P0(litmus_test_run* data) {
 
 static void svc_handler1(void) {
   asm volatile(
-      /* x3 = X */
-      "ldr x0, [x1]\n\t"
+      "dmb sy\n\t"
       "eret\n\t");
 }
 
@@ -48,6 +47,8 @@ static void P1(litmus_test_run* data) {
       "mov x3, %[x]\n\t"
 
       /* test */
+      /* x3 = X */
+      "ldr x0, [x1]\n\t"
       "svc #0\n\t"
       "str x2, [x3]\n\t"
 

--- a/litmus/litmus_tests/exc/LB+svc-erets.c
+++ b/litmus/litmus_tests/exc/LB+svc-erets.c
@@ -24,7 +24,6 @@ static void P0(litmus_test_run* data) {
 
       /* extract values */
       "str x0, [%[outp0r0]]\n\t"
-      "dmb st\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)
@@ -52,7 +51,6 @@ static void P1(litmus_test_run* data) {
 
       /* extract values  */
       "str x0, [%[outp1r0]]\n\t"
-      "dmb st\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)

--- a/litmus/litmus_tests/exc/LB+svc-erets.c
+++ b/litmus/litmus_tests/exc/LB+svc-erets.c
@@ -82,4 +82,5 @@ litmus_test_t LB_svcerets = {
       /* p0:x2 =*/1,
       /* p1:x2 =*/1,
   },
+  .no_sc_results = 3,
 };

--- a/litmus/litmus_tests/exc/LB+svc-erets.c
+++ b/litmus/litmus_tests/exc/LB+svc-erets.c
@@ -1,0 +1,85 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p0x0, p1x0
+
+static void svc_handler0(void) {
+  asm volatile(
+      "eret\n\t");
+}
+
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+    /*initial registers */
+      "mov x2, #1\n\t"
+      "mov x1, %[x]\n\t"
+      "mov x3, %[y]\n\t"
+
+      /* test */
+      "ldr x0, [x1]\n\t"
+      "svc #0\n\t"
+      /* x3 = Y */
+      "str x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp0r0]]\n\t"
+      "dmb st\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3"
+  );
+}
+
+static void svc_handler1(void) {
+  asm volatile(
+      /* x3 = X */
+      "ldr x0, [x1]\n\t"
+      "eret\n\t");
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* initial registers */
+      "mov x2, #1\n\t"
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* test */
+      "svc #0\n\t"
+      "str x2, [x3]\n\t"
+
+      /* extract values  */
+      "str x0, [%[outp1r0]]\n\t"
+      "dmb st\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+
+
+litmus_test_t LB_svcerets = {
+  "LB+svc-erets",
+  MAKE_THREADS(2),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+     (u32*[]){(u32*)svc_handler0, NULL},
+     (u32*[]){(u32*)svc_handler1, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p0:x2 =*/1,
+      /* p1:x2 =*/1,
+  },
+};

--- a/litmus/litmus_tests/exc/LB+svc-erets.c
+++ b/litmus/litmus_tests/exc/LB+svc-erets.c
@@ -34,8 +34,6 @@ static void P0(litmus_test_run* data) {
 
 static void svc_handler1(void) {
   asm volatile(
-      /* x3 = X */
-      "ldr x0, [x1]\n\t"
       "eret\n\t");
 }
 
@@ -47,6 +45,8 @@ static void P1(litmus_test_run* data) {
       "mov x3, %[x]\n\t"
 
       /* test */
+      /* x3 = X */
+      "ldr x0, [x1]\n\t"
       "svc #0\n\t"
       "str x2, [x3]\n\t"
 

--- a/litmus/litmus_tests/exc/LB+svcs.c
+++ b/litmus/litmus_tests/exc/LB+svcs.c
@@ -24,7 +24,6 @@ static void P0(litmus_test_run* data) {
 
       /* extract values */
       "str x0, [%[outp0r0]]\n\t"
-      "dmb st\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)
@@ -52,7 +51,6 @@ static void P1(litmus_test_run* data) {
 
       /* extract values  */
       "str x0, [%[outp1r0]]\n\t"
-      "dmb st\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)

--- a/litmus/litmus_tests/exc/LB+svcs.c
+++ b/litmus/litmus_tests/exc/LB+svcs.c
@@ -1,4 +1,3 @@
-// deprecated: use LB+svcs.c instead
 #include "lib.h"
 
 #define VARS x, y
@@ -19,8 +18,10 @@ static void P0(litmus_test_run* data) {
       "mov x1, %[x]\n\t"
       "mov x3, %[y]\n\t"
 
+      /* test */
       "ldr x0, [x1]\n\t"
       "svc #0\n\t"
+
       /* extract values */
       "str x0, [%[outp0r0]]\n\t"
       "dmb st\n\t"
@@ -45,8 +46,11 @@ static void P1(litmus_test_run* data) {
       "mov x1, %[y]\n\t"
       "mov x3, %[x]\n\t"
 
+      /* test */
       "ldr x0, [x1]\n\t"
       "svc #0\n\t"
+
+      /* extract values  */
       "str x0, [%[outp1r0]]\n\t"
       "dmb st\n\t"
   :
@@ -59,8 +63,8 @@ static void P1(litmus_test_run* data) {
 
 
 
-litmus_test_t LB_RsvcW_RsvcW = {
-  "LB+R-svc-W+R-svc-W",
+litmus_test_t LB_svcs = {
+  "LB+svcs",
   MAKE_THREADS(2),
   MAKE_VARS(VARS),
   MAKE_REGS(REGS),

--- a/litmus/litmus_tests/exc/LB+svcs.c
+++ b/litmus/litmus_tests/exc/LB+svcs.c
@@ -82,4 +82,5 @@ litmus_test_t LB_svcs = {
       /* p0:x2 =*/1,
       /* p1:x2 =*/1,
   },
+  .no_sc_results = 3,
 };

--- a/litmus/litmus_tests/exc/MP+dmb+ctrl-eret.c
+++ b/litmus/litmus_tests/exc/MP+dmb+ctrl-eret.c
@@ -68,4 +68,5 @@ litmus_test_t MP_dmb_ctrleret = {
       /* p1:x0 =*/1,
       /* p1:x2 =*/0,
   },
+  .no_sc_results = 3,
 };

--- a/litmus/litmus_tests/exc/MP+dmb+ctrl-eret.c
+++ b/litmus/litmus_tests/exc/MP+dmb+ctrl-eret.c
@@ -1,0 +1,71 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p1x0, p1x2
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+    "mov x0, #1\n\t"
+      "str x0, [%[x]]\n\t"
+      "dmb sy\n\t"
+      "mov x2, #1\n\t"
+      "str x2, [%[y]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x2"
+  );
+}
+
+static void svc_handler(void) {
+  asm volatile(
+      /* x1 = Y */
+      "ldr x0, [x1]\n\t"
+      "cbz x0, .lc\n\t"
+      ".lc:\n\t"
+      "eret\n\t");
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* initial registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* test */
+      "svc #0\n\t"
+      "ldr x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp1r0]]\n\t"
+      "str x2, [%[outp1r2]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+
+
+litmus_test_t MP_dmb_ctrleret = {
+  "MP+dmb+ctrl-eret",
+  MAKE_THREADS(2),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+     (u32*[]){NULL, NULL},
+     (u32*[]){(u32*)svc_handler, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p1:x0 =*/1,
+      /* p1:x2 =*/0,
+  },
+};

--- a/litmus/litmus_tests/exc/MP+dmb+ctrl-svc.c
+++ b/litmus/litmus_tests/exc/MP+dmb+ctrl-svc.c
@@ -68,4 +68,5 @@ litmus_test_t MP_dmb_ctrl_svc = {
       /* p1:x0 =*/1,
       /* p1:x2 =*/0,
   },
+  .no_sc_results = 3,
 };

--- a/litmus/litmus_tests/exc/MP+dmb+ctrl-svc.c
+++ b/litmus/litmus_tests/exc/MP+dmb+ctrl-svc.c
@@ -1,0 +1,71 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p1x0, p1x2
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+      "mov x0, #1\n\t"
+      "str x0, [%[x]]\n\t"
+      "dmb sy\n\t"
+      "mov x2, #1\n\t"
+      "str x2, [%[y]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x2"
+  );
+}
+
+static void svc_handler(void) {
+  asm volatile(
+      /* x3 = X */
+      "ldr x2, [x3]\n\t"
+      "eret\n\t"
+  );
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* load variables into machine registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      "ldr x0, [x1]\n\t"
+      "cbz x0, .lc\n\t"
+      ".lc:\n\t"
+      "svc #0\n\t"
+      /* extract values */
+      "str x0, [%[outp1r0]]\n\t"
+      "str x2, [%[outp1r2]]\n\t"
+      "dmb st\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+
+
+litmus_test_t MP_dmb_ctrl_svc = {
+  "MP+dmb+ctrl-svc",
+  MAKE_THREADS(2),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+     (u32*[]){NULL, NULL},
+     (u32*[]){(u32*)svc_handler, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p1:x0 =*/1,
+      /* p1:x2 =*/0,
+  },
+};

--- a/litmus/litmus_tests/exc/MP+dmb+ctrl-svc.c
+++ b/litmus/litmus_tests/exc/MP+dmb+ctrl-svc.c
@@ -38,7 +38,6 @@ static void P1(litmus_test_run* data) {
       /* extract values */
       "str x0, [%[outp1r0]]\n\t"
       "str x2, [%[outp1r2]]\n\t"
-      "dmb st\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)

--- a/litmus/litmus_tests/exc/MP+dmb+ctrl-svc.c
+++ b/litmus/litmus_tests/exc/MP+dmb+ctrl-svc.c
@@ -35,6 +35,7 @@ static void P1(litmus_test_run* data) {
       "cbz x0, .lc\n\t"
       ".lc:\n\t"
       "svc #0\n\t"
+
       /* extract values */
       "str x0, [%[outp1r0]]\n\t"
       "str x2, [%[outp1r2]]\n\t"

--- a/litmus/litmus_tests/exc/MP+dmb+data-svc.c
+++ b/litmus/litmus_tests/exc/MP+dmb+data-svc.c
@@ -56,7 +56,7 @@ litmus_test_t MP_dmb_datasvc = {
   MAKE_VARS(VARS),
   MAKE_REGS(REGS),
   INIT_STATE(
-    2,
+    3,
     INIT_VAR(x, 0),
     INIT_VAR(y, 0),
     INIT_VAR(z, 0),

--- a/litmus/litmus_tests/exc/MP+dmb+data-svc.c
+++ b/litmus/litmus_tests/exc/MP+dmb+data-svc.c
@@ -70,4 +70,5 @@ litmus_test_t MP_dmb_datasvc = {
       /* p1:x0 =*/1,
       /* p1:x2 =*/0,
   },
+  .no_sc_results = 3,
 };

--- a/litmus/litmus_tests/exc/MP+dmb+data-svc.c
+++ b/litmus/litmus_tests/exc/MP+dmb+data-svc.c
@@ -1,0 +1,73 @@
+#include "lib.h"
+
+#define VARS x, y, z
+#define REGS p1x0, p1x2
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+      "mov x0, #1\n\t"
+      "str x0, [%[x]]\n\t"
+      "dmb sy\n\t"
+      "mov x2, #1\n\t"
+      "str x2, [%[y]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x2"
+  );
+}
+
+static void svc_handler(void) {
+  asm volatile(
+      /* x3 = X */
+      "ldr x2, [x3]\n\t"
+      "eret\n\t"
+  );
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* load variables into machine registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+      "mov x5, %[z]\n\t"
+
+      "ldr x0, [x1]\n\t"
+      "mov x4, x0\n\t"
+      "str x4, [x5]\n\t"
+      "svc #0\n\t"
+      /* extract values */
+      "str x0, [%[outp1r0]]\n\t"
+      "str x2, [%[outp1r2]]\n\t"
+      "dmb st\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+
+
+litmus_test_t MP_dmb_datasvc = {
+  "MP+dmb+data-svc",
+  MAKE_THREADS(2),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0),
+    INIT_VAR(z, 0),
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+     (u32*[]){NULL, NULL},
+     (u32*[]){(u32*)svc_handler, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p1:x0 =*/1,
+      /* p1:x2 =*/0,
+  },
+};

--- a/litmus/litmus_tests/exc/MP+dmb+data-svc.c
+++ b/litmus/litmus_tests/exc/MP+dmb+data-svc.c
@@ -39,7 +39,6 @@ static void P1(litmus_test_run* data) {
       /* extract values */
       "str x0, [%[outp1r0]]\n\t"
       "str x2, [%[outp1r2]]\n\t"
-      "dmb st\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)

--- a/litmus/litmus_tests/exc/MP+dmb+dmb-eret.c
+++ b/litmus/litmus_tests/exc/MP+dmb+dmb-eret.c
@@ -68,4 +68,5 @@ litmus_test_t MP_dmb_dmberet = {
       /* p1:x0 =*/1,
       /* p1:x2 =*/0,
   },
+  .no_sc_results = 3,
 };

--- a/litmus/litmus_tests/exc/MP+dmb+svc-addreret.c
+++ b/litmus/litmus_tests/exc/MP+dmb+svc-addreret.c
@@ -22,7 +22,7 @@ static void svc_handler(void) {
       "ldr x4, [x5]\n\t"
       "mrs x6, elr_el1\n\t"
       "eor x8, x4, x4\n\t"
-      "add x10, x6, x4\n\t"
+      "add x10, x6, x8\n\t"
       "msr elr_el1, x10\n\t"
       "eret\n\t");
 }

--- a/litmus/litmus_tests/exc/MP+dmb+svc-addreret.c
+++ b/litmus/litmus_tests/exc/MP+dmb+svc-addreret.c
@@ -1,0 +1,75 @@
+#include "lib.h"
+
+#define VARS x, y, z
+#define REGS p1x0, p1x2
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+    "mov x0, #1\n\t"
+      "str x0, [%[x]]\n\t"
+      "dmb sy\n\t"
+      "mov x2, #1\n\t"
+      "str x2, [%[y]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x2"
+  );
+}
+
+static void svc_handler(void) {
+  asm volatile(
+      "ldr x4, [x5]\n\t"
+      "mrs x6, elr_el1\n\t"
+      "eor x8, x4, x4\n\t"
+      "add x10, x6, x4\n\t"
+      "msr elr_el1, x10\n\t"
+      "eret\n\t");
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* initial registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+      "mov x5, %[z]\n\t"
+
+      /* test */
+      /* x1 = Y */
+      "ldr x0, [x1]\n\t"
+      "svc #0\n\t"
+      "ldr x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp1r0]]\n\t"
+      "str x2, [%[outp1r2]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+    "x7", "x8", "x10" /* dont touch parameter registers */
+  );
+}
+
+
+
+litmus_test_t MP_dmb_svcaddreret = {
+  "MP+dmb+svc-addreret",
+  MAKE_THREADS(2),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+     (u32*[]){NULL, NULL},
+     (u32*[]){(u32*)svc_handler, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p1:x0 =*/1,
+      /* p1:x2 =*/0,
+  },
+};

--- a/litmus/litmus_tests/exc/MP+dmb+svc-addreret.c
+++ b/litmus/litmus_tests/exc/MP+dmb+svc-addreret.c
@@ -73,4 +73,5 @@ litmus_test_t MP_dmb_svcaddreret = {
       /* p1:x0 =*/1,
       /* p1:x2 =*/0,
   },
+  .no_sc_results = 3,
 };

--- a/litmus/litmus_tests/exc/MP+dmb+svc-addreret.c
+++ b/litmus/litmus_tests/exc/MP+dmb+svc-addreret.c
@@ -59,9 +59,10 @@ litmus_test_t MP_dmb_svcaddreret = {
   MAKE_VARS(VARS),
   MAKE_REGS(REGS),
   INIT_STATE(
-    2,
+    3,
     INIT_VAR(x, 0),
-    INIT_VAR(y, 0)
+    INIT_VAR(y, 0),
+    INIT_VAR(z, 0),
   ),
   .thread_sync_handlers =
     (u32**[]){

--- a/litmus/litmus_tests/exc/MP+dmb+svc-dmb-eret.c
+++ b/litmus/litmus_tests/exc/MP+dmb+svc-dmb-eret.c
@@ -1,0 +1,70 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p1x0, p1x2
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+    "mov x0, #1\n\t"
+      "str x0, [%[x]]\n\t"
+      "dmb sy\n\t"
+      "mov x2, #1\n\t"
+      "str x2, [%[y]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x2"
+  );
+}
+
+static void svc_handler(void) {
+  asm volatile(
+      "dmb sy\n\t"
+      "eret\n\t");
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* initial registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* test */
+      /* x1 = Y */
+      "ldr x0, [x1]\n\t"
+      "svc #0\n\t"
+      "ldr x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp1r0]]\n\t"
+      "str x2, [%[outp1r2]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+
+
+litmus_test_t MP_dmb_svcdmberet = {
+  "MP+dmb+svc-dmb-eret",
+  MAKE_THREADS(2),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+     (u32*[]){NULL, NULL},
+     (u32*[]){(u32*)svc_handler, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p1:x0 =*/1,
+      /* p1:x2 =*/0,
+  },
+};

--- a/litmus/litmus_tests/exc/MP+dmb+svc-dmb-eret.c
+++ b/litmus/litmus_tests/exc/MP+dmb+svc-dmb-eret.c
@@ -67,4 +67,5 @@ litmus_test_t MP_dmb_svcdmberet = {
       /* p1:x0 =*/1,
       /* p1:x2 =*/0,
   },
+  .no_sc_results = 3,
 };

--- a/litmus/litmus_tests/exc/MP+dmb+svc-eret.c
+++ b/litmus/litmus_tests/exc/MP+dmb+svc-eret.c
@@ -66,4 +66,5 @@ litmus_test_t MP_dmb_svceret = {
       /* p1:x0 =*/1,
       /* p1:x2 =*/0,
   },
+  .no_sc_results = 3,
 };

--- a/litmus/litmus_tests/exc/MP+dmb+svc-eret.c
+++ b/litmus/litmus_tests/exc/MP+dmb+svc-eret.c
@@ -1,0 +1,69 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p1x0, p1x2
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+    "mov x0, #1\n\t"
+      "str x0, [%[x]]\n\t"
+      "dmb sy\n\t"
+      "mov x2, #1\n\t"
+      "str x2, [%[y]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x2"
+  );
+}
+
+static void svc_handler(void) {
+  asm volatile(
+      "eret\n\t");
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* initial registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* test */
+      /* x1 = Y */
+      "ldr x0, [x1]\n\t"
+      "svc #0\n\t"
+      "ldr x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp1r0]]\n\t"
+      "str x2, [%[outp1r2]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+
+
+litmus_test_t MP_dmb_svceret = {
+  "MP+dmb+svc-eret",
+  MAKE_THREADS(2),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+     (u32*[]){NULL, NULL},
+     (u32*[]){(u32*)svc_handler, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p1:x0 =*/1,
+      /* p1:x2 =*/0,
+  },
+};

--- a/litmus/litmus_tests/exc/MP+erets.c
+++ b/litmus/litmus_tests/exc/MP+erets.c
@@ -1,0 +1,83 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p1x0, p1x2
+
+static void svc_handler0(void) {
+  asm volatile(
+      "mov x0, #1\n\t"
+      "str x0, [x4]\n\t"
+      "eret\n\t"
+  );
+}
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+      /* initialise registers */
+      "mov x4, %[x]\n\t"
+      "mov x6, %[y]\n\t"
+
+      /* test */
+      "svc #0\n\t"
+      "mov x2, #1\n\t"
+      "str x2, [x6]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x2", "x4", "x6"
+  );
+}
+
+static void svc_handler1(void) {
+  asm volatile(
+      /* x1 = Y */
+      "ldr x0, [x1]\n\t"
+      "eret\n\t"
+  );
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* load variables into machine registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* test  */
+      "svc #0\n\t"
+      /* x3 = X */
+      "ldr x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp1r0]]\n\t"
+      "str x2, [%[outp1r2]]\n\t"
+      "dmb st\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+
+
+litmus_test_t MP_erets = {
+  "MP+erets",
+  MAKE_THREADS(2),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+      (u32*[]){(u32*)svc_handler0, NULL},
+      (u32*[]){(u32*)svc_handler1, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p1:x0 =*/1,
+      /* p1:x2 =*/0,
+  },
+};

--- a/litmus/litmus_tests/exc/MP+erets.c
+++ b/litmus/litmus_tests/exc/MP+erets.c
@@ -50,7 +50,6 @@ static void P1(litmus_test_run* data) {
       /* extract values */
       "str x0, [%[outp1r0]]\n\t"
       "str x2, [%[outp1r2]]\n\t"
-      "dmb st\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)

--- a/litmus/litmus_tests/exc/MP+erets.c
+++ b/litmus/litmus_tests/exc/MP+erets.c
@@ -80,4 +80,5 @@ litmus_test_t MP_erets = {
       /* p1:x0 =*/1,
       /* p1:x2 =*/0,
   },
+  .no_sc_results = 3,
 };

--- a/litmus/litmus_tests/exc/MP+svc-erets.c
+++ b/litmus/litmus_tests/exc/MP+svc-erets.c
@@ -50,7 +50,6 @@ static void P1(litmus_test_run* data) {
       /* extract values */
       "str x0, [%[outp1r0]]\n\t"
       "str x2, [%[outp1r2]]\n\t"
-      "dmb st\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)

--- a/litmus/litmus_tests/exc/MP+svc-erets.c
+++ b/litmus/litmus_tests/exc/MP+svc-erets.c
@@ -1,0 +1,83 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p1x0, p1x2
+
+static void svc_handler0(void) {
+  asm volatile(
+      "eret\n\t"
+  );
+}
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+      /* initialise registers */
+      "mov x4, %[x]\n\t"
+      "mov x6, %[y]\n\t"
+
+      /* test */
+      "mov x0, #1\n\t"
+      "str x0, [x4]\n\t"
+      "svc #0\n\t"
+      "mov x2, #1\n\t"
+      "str x2, [x6]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x2", "x4", "x6"
+  );
+}
+
+static void svc_handler1(void) {
+  asm volatile(
+      "eret\n\t"
+  );
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* load variables into machine registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* test  */
+      /* x1 = Y */
+      "ldr x0, [x1]\n\t"
+      "svc #0\n\t"
+      /* x3 = X */
+      "ldr x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp1r0]]\n\t"
+      "str x2, [%[outp1r2]]\n\t"
+      "dmb st\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+
+
+litmus_test_t MP_svcerets = {
+  "MP+svc-erets",
+  MAKE_THREADS(2),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+      (u32*[]){(u32*)svc_handler0, NULL},
+      (u32*[]){(u32*)svc_handler1, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p1:x0 =*/1,
+      /* p1:x2 =*/0,
+  },
+};

--- a/litmus/litmus_tests/exc/MP+svc-erets.c
+++ b/litmus/litmus_tests/exc/MP+svc-erets.c
@@ -80,4 +80,5 @@ litmus_test_t MP_svcerets = {
       /* p1:x0 =*/1,
       /* p1:x2 =*/0,
   },
+  .no_sc_results = 3,
 };

--- a/litmus/litmus_tests/exc/MP+svcs.c
+++ b/litmus/litmus_tests/exc/MP+svcs.c
@@ -1,0 +1,82 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p1x0, p1x2
+
+static void svc_handler0(void) {
+  asm volatile(
+      "mov x2, #1\n\t"
+      "str x2, [x6]\n\t"
+      "eret\n\t"
+  );
+}
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+      /* initialise registers */
+      "mov x4, %[x]\n\t"
+      "mov x6, %[y]\n\t"
+
+      /* test */
+      "mov x0, #1\n\t"
+      "str x0, [x4]\n\t"
+      "svc #0\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x2", "x4", "x6"
+  );
+}
+
+static void svc_handler1(void) {
+  asm volatile(
+      /* x3 = X */
+      "ldr x2, [x3]\n\t"
+      "eret\n\t"
+  );
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* load variables into machine registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* test  */
+      "ldr x0, [x1]\n\t"
+      "svc #0\n\t"
+
+      /* extract values */
+      "str x0, [%[outp1r0]]\n\t"
+      "str x2, [%[outp1r2]]\n\t"
+      "dmb st\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+
+
+litmus_test_t MP_svcs = {
+  "MP+svcs",
+  MAKE_THREADS(2),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+      (u32*[]){(u32*)svc_handler0, NULL},
+      (u32*[]){(u32*)svc_handler1, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p1:x0 =*/1,
+      /* p1:x2 =*/0,
+  },
+};

--- a/litmus/litmus_tests/exc/MP+svcs.c
+++ b/litmus/litmus_tests/exc/MP+svcs.c
@@ -79,4 +79,5 @@ litmus_test_t MP_svcs = {
       /* p1:x0 =*/1,
       /* p1:x2 =*/0,
   },
+  .no_sc_results = 3,
 };

--- a/litmus/litmus_tests/exc/MP+svcs.c
+++ b/litmus/litmus_tests/exc/MP+svcs.c
@@ -49,7 +49,6 @@ static void P1(litmus_test_run* data) {
       /* extract values */
       "str x0, [%[outp1r0]]\n\t"
       "str x2, [%[outp1r2]]\n\t"
-      "dmb st\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)

--- a/litmus/litmus_tests/exc/S+erets.c
+++ b/litmus/litmus_tests/exc/S+erets.c
@@ -61,7 +61,6 @@ static void P1(litmus_test_run* data) {
 static void P2(litmus_test_run* data) {
   asm volatile (
     /* load variables into machine registers */
-      "mov x1, %[y]\n\t"
       "mov x3, %[x]\n\t"
 
       /* observe  */

--- a/litmus/litmus_tests/exc/S+erets.c
+++ b/litmus/litmus_tests/exc/S+erets.c
@@ -1,0 +1,104 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p1x0, p2x0, p2x2
+
+static void svc_handler0(void) {
+  asm volatile(
+      "mov x2, #1\n\t"
+      "str x2, [x6]\n\t"
+      "eret\n\t"
+  );
+}
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+      /* initialise registers */
+      "mov x4, %[x]\n\t"
+      "mov x6, %[y]\n\t"
+
+      /* test */
+      "mov x0, #2\n\t"
+      "str x0, [x4]\n\t"
+      "svc #0\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x2", "x4", "x6"
+  );
+}
+
+static void svc_handler1(void) {
+  asm volatile(
+      "ldr x0, [x1]\n\t"
+      "eret\n\t"
+  );
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* load variables into machine registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* test  */
+      "svc #0\n\t"
+      /* x3 = X */
+      "mov x2, #1\n\t"
+      "str x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp1r0]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+/* Observer thread */
+static void P2(litmus_test_run* data) {
+  asm volatile (
+    /* load variables into machine registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* observe  */
+      "ldr x0, [x3]\n\t"
+      "ldr x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp2r0]]\n\t"
+      "str x2, [%[outp2r2]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+
+litmus_test_t S_erets = {
+  "S+erets",
+  MAKE_THREADS(3),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+      (u32*[]){(u32*)svc_handler0, NULL},
+      (u32*[]){(u32*)svc_handler1, NULL},
+      (u32*[]){NULL, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p1:x0 =*/1,
+      /* p2:x0 =*/1,
+      /* p2:x2 =*/2,
+  },
+};

--- a/litmus/litmus_tests/exc/S+erets.c
+++ b/litmus/litmus_tests/exc/S+erets.c
@@ -5,8 +5,8 @@
 
 static void svc_handler0(void) {
   asm volatile(
-      "mov x2, #1\n\t"
-      "str x2, [x6]\n\t"
+      "mov x0, #2\n\t"
+      "str x0, [x4]\n\t"
       "eret\n\t"
   );
 }
@@ -18,9 +18,9 @@ static void P0(litmus_test_run* data) {
       "mov x6, %[y]\n\t"
 
       /* test */
-      "mov x0, #2\n\t"
-      "str x0, [x4]\n\t"
       "svc #0\n\t"
+      "mov x2, #1\n\t"
+      "str x2, [x6]\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)

--- a/litmus/litmus_tests/exc/S+erets.c
+++ b/litmus/litmus_tests/exc/S+erets.c
@@ -101,4 +101,5 @@ litmus_test_t S_erets = {
       /* p2:x0 =*/1,
       /* p2:x2 =*/2,
   },
+  .no_sc_results = 8,
 };

--- a/litmus/litmus_tests/exc/S+svc-dmb-erets.c
+++ b/litmus/litmus_tests/exc/S+svc-dmb-erets.c
@@ -103,4 +103,5 @@ litmus_test_t S_svcdmberets = {
       /* p2:x0 =*/1,
       /* p2:x2 =*/2,
   },
+  .no_sc_results = 8,
 };

--- a/litmus/litmus_tests/exc/S+svc-dmb-erets.c
+++ b/litmus/litmus_tests/exc/S+svc-dmb-erets.c
@@ -63,7 +63,6 @@ static void P1(litmus_test_run* data) {
 static void P2(litmus_test_run* data) {
   asm volatile (
     /* load variables into machine registers */
-      "mov x1, %[y]\n\t"
       "mov x3, %[x]\n\t"
 
       /* observe  */

--- a/litmus/litmus_tests/exc/S+svc-dmb-erets.c
+++ b/litmus/litmus_tests/exc/S+svc-dmb-erets.c
@@ -1,0 +1,106 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p1x0, p2x0, p2x2
+
+static void svc_handler0(void) {
+  asm volatile(
+      "dmb sy\n\t"
+      "eret\n\t"
+  );
+}
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+      /* initialise registers */
+      "mov x4, %[x]\n\t"
+      "mov x6, %[y]\n\t"
+
+      /* test */
+      "mov x0, #2\n\t"
+      "str x0, [x4]\n\t"
+      "svc #0\n\t"
+      "mov x2, #1\n\t"
+      "str x2, [x6]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x2", "x4", "x6"
+  );
+}
+
+static void svc_handler1(void) {
+  asm volatile(
+      "dmb sy\n\t"
+      "eret\n\t"
+  );
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* load variables into machine registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* test  */
+      "ldr x0, [x1]\n\t"
+      "svc #0\n\t"
+      /* x3 = X */
+      "mov x2, #1\n\t"
+      "str x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp1r0]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+/* Observer thread */
+static void P2(litmus_test_run* data) {
+  asm volatile (
+    /* load variables into machine registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* observe  */
+      "ldr x0, [x3]\n\t"
+      "ldr x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp2r0]]\n\t"
+      "str x2, [%[outp2r2]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+
+litmus_test_t S_svcdmberets = {
+  "S+svc-dmb-erets",
+  MAKE_THREADS(3),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+      (u32*[]){(u32*)svc_handler0, NULL},
+      (u32*[]){(u32*)svc_handler1, NULL},
+      (u32*[]){NULL, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p1:x0 =*/1,
+      /* p2:x0 =*/1,
+      /* p2:x2 =*/2,
+  },
+};

--- a/litmus/litmus_tests/exc/S+svc-erets.c
+++ b/litmus/litmus_tests/exc/S+svc-erets.c
@@ -61,7 +61,6 @@ static void P1(litmus_test_run* data) {
 static void P2(litmus_test_run* data) {
   asm volatile (
     /* load variables into machine registers */
-      "mov x1, %[y]\n\t"
       "mov x3, %[x]\n\t"
 
       /* observe  */

--- a/litmus/litmus_tests/exc/S+svc-erets.c
+++ b/litmus/litmus_tests/exc/S+svc-erets.c
@@ -1,0 +1,104 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p1x0, p2x0, p2x2
+
+static void svc_handler0(void) {
+  asm volatile(
+      "eret\n\t"
+  );
+}
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+      /* initialise registers */
+      "mov x4, %[x]\n\t"
+      "mov x6, %[y]\n\t"
+
+      /* test */
+      "mov x0, #2\n\t"
+      "str x0, [x4]\n\t"
+      "svc #0\n\t"
+      "mov x2, #1\n\t"
+      "str x2, [x6]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x2", "x4", "x6"
+  );
+}
+
+static void svc_handler1(void) {
+  asm volatile(
+      /* x3 = X */
+      "eret\n\t"
+  );
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* load variables into machine registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* test  */
+      "ldr x0, [x1]\n\t"
+      "svc #0\n\t"
+      "mov x2, #1\n\t"
+      "str x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp1r0]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+/* Observer thread */
+static void P2(litmus_test_run* data) {
+  asm volatile (
+    /* load variables into machine registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* observe  */
+      "ldr x0, [x3]\n\t"
+      "ldr x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp2r0]]\n\t"
+      "str x2, [%[outp2r2]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+
+litmus_test_t S_svcserets = {
+  "S+svcs-erets",
+  MAKE_THREADS(3),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+      (u32*[]){(u32*)svc_handler0, NULL},
+      (u32*[]){(u32*)svc_handler1, NULL},
+      (u32*[]){NULL, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p1:x0 =*/1,
+      /* p2:x0 =*/1,
+      /* p2:x2 =*/2,
+  },
+};

--- a/litmus/litmus_tests/exc/S+svc-erets.c
+++ b/litmus/litmus_tests/exc/S+svc-erets.c
@@ -101,4 +101,5 @@ litmus_test_t S_svcerets = {
       /* p2:x0 =*/1,
       /* p2:x2 =*/2,
   },
+  .no_sc_results = 8,
 };

--- a/litmus/litmus_tests/exc/S+svc-erets.c
+++ b/litmus/litmus_tests/exc/S+svc-erets.c
@@ -80,8 +80,8 @@ static void P2(litmus_test_run* data) {
 }
 
 
-litmus_test_t S_svcserets = {
-  "S+svcs-erets",
+litmus_test_t S_svcerets = {
+  "S+svc-erets",
   MAKE_THREADS(3),
   MAKE_VARS(VARS),
   MAKE_REGS(REGS),

--- a/litmus/litmus_tests/exc/S+svcs.c
+++ b/litmus/litmus_tests/exc/S+svcs.c
@@ -61,7 +61,6 @@ static void P1(litmus_test_run* data) {
 static void P2(litmus_test_run* data) {
   asm volatile (
     /* load variables into machine registers */
-      "mov x1, %[y]\n\t"
       "mov x3, %[x]\n\t"
 
       /* observe  */

--- a/litmus/litmus_tests/exc/S+svcs.c
+++ b/litmus/litmus_tests/exc/S+svcs.c
@@ -1,7 +1,7 @@
 #include "lib.h"
 
 #define VARS x, y
-#define REGS p1x0, p1x2
+#define REGS p1x0, p2x0, p2x2
 
 static void svc_handler0(void) {
   asm volatile(
@@ -46,6 +46,9 @@ static void P1(litmus_test_run* data) {
       /* test  */
       "ldr x0, [x1]\n\t"
       "svc #0\n\t"
+
+      /* extract values */
+      "str x0, [%[outp1r0]]\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)
@@ -68,7 +71,6 @@ static void P2(litmus_test_run* data) {
       /* extract values */
       "str x0, [%[outp2r0]]\n\t"
       "str x2, [%[outp2r2]]\n\t"
-      "dmb st\n\t"
   :
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)
@@ -95,6 +97,7 @@ litmus_test_t S_svcs = {
       (u32*[]){NULL, NULL},
     },
   .interesting_result = (u64[]){
+      /* p1:x0 =*/1,
       /* p2:x0 =*/1,
       /* p2:x2 =*/2,
   },

--- a/litmus/litmus_tests/exc/S+svcs.c
+++ b/litmus/litmus_tests/exc/S+svcs.c
@@ -1,0 +1,101 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p1x0, p1x2
+
+static void svc_handler0(void) {
+  asm volatile(
+      "mov x2, #1\n\t"
+      "str x2, [x6]\n\t"
+      "eret\n\t"
+  );
+}
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+      /* initialise registers */
+      "mov x4, %[x]\n\t"
+      "mov x6, %[y]\n\t"
+
+      /* test */
+      "mov x0, #2\n\t"
+      "str x0, [x4]\n\t"
+      "svc #0\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x2", "x4", "x6"
+  );
+}
+
+static void svc_handler1(void) {
+  asm volatile(
+      /* x3 = X */
+      "mov x2, #1\n\t"
+      "str x2, [x3]\n\t"
+      "eret\n\t"
+  );
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* load variables into machine registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* test  */
+      "ldr x0, [x1]\n\t"
+      "svc #0\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+/* Observer thread */
+static void P2(litmus_test_run* data) {
+  asm volatile (
+    /* load variables into machine registers */
+      "mov x1, %[y]\n\t"
+      "mov x3, %[x]\n\t"
+
+      /* observe  */
+      "ldr x0, [x3]\n\t"
+      "ldr x2, [x3]\n\t"
+
+      /* extract values */
+      "str x0, [%[outp2r0]]\n\t"
+      "str x2, [%[outp2r2]]\n\t"
+      "dmb st\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3", "x4", "x5", "x6",
+        "x7" /* dont touch parameter registers */
+  );
+}
+
+
+litmus_test_t S_svcs = {
+  "S+svcs",
+  MAKE_THREADS(3),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers =
+    (u32**[]){
+      (u32*[]){(u32*)svc_handler0, NULL},
+      (u32*[]){(u32*)svc_handler1, NULL},
+      (u32*[]){NULL, NULL},
+    },
+  .interesting_result = (u64[]){
+      /* p2:x0 =*/1,
+      /* p2:x2 =*/2,
+  },
+};

--- a/litmus/litmus_tests/exc/S+svcs.c
+++ b/litmus/litmus_tests/exc/S+svcs.c
@@ -101,4 +101,5 @@ litmus_test_t S_svcs = {
       /* p2:x0 =*/1,
       /* p2:x2 =*/2,
   },
+  .no_sc_results = 8,
 };

--- a/litmus/litmus_tests/exc/SB+dmb+rfi-ctrl-eret.c
+++ b/litmus/litmus_tests/exc/SB+dmb+rfi-ctrl-eret.c
@@ -1,0 +1,79 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p0x2, p1x2
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+    /* initial registers */
+    "mov x0, #1\n\t"
+    "mov x1, %[x]\n\t"
+    "mov x3, %[y]\n\t"
+
+    /* test */
+    "str x0, [x1]\n\t"
+    "dmb st\n\t"
+    "ldr x2, [x3]\n\t"
+
+    /* extract values */
+    "str x2, [%[outp0r2]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3"
+  );
+}
+
+static void svc_handler1(void) {
+  asm volatile (
+    "str x0, [x1]\n\t"
+    "ldr x4, [x1]\n\t"
+    "cbz x4, .lc\n\t"
+    ".lc:\n\t"
+    "eret\n\t"
+  );
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* initial registers */
+    "mov x0, #1\n\t"
+    "mov x1, %[y]\n\t"
+    "mov x3, %[x]\n\t"
+
+    /* test */
+    "svc #0\n\t"
+    "ldr x2, [x3]\n\t"
+
+    /* extract values */
+    "str x2, [%[outp1r2]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+    : "cc", "memory", "x0", "x1", "x2", "x3", "x4"
+  );
+}
+
+litmus_test_t SB_dmb_rfictrleret = {
+  "SB+dmb+rfi-ctrl-eret",
+  MAKE_THREADS(2),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers = (u32**[]){
+     (u32*[]){NULL, NULL},
+     (u32*[]){(u32*)svc_handler1, NULL},
+  },
+  .interesting_result = (u64[]){
+      /* p0:x2 =*/0,
+      /* p1:x2 =*/0,
+  },
+  .no_sc_results=3,
+  .expected_allowed = (arch_allow_st[]) {
+    {"armv8", OUTCOME_UNKNOWN},
+  }
+};

--- a/litmus/litmus_tests/exc/SB+dmb+rfi-ctrl-eret.c
+++ b/litmus/litmus_tests/exc/SB+dmb+rfi-ctrl-eret.c
@@ -12,7 +12,7 @@ static void P0(litmus_test_run* data) {
 
     /* test */
     "str x0, [x1]\n\t"
-    "dmb st\n\t"
+    "dmb sy\n\t"
     "ldr x2, [x3]\n\t"
 
     /* extract values */

--- a/litmus/litmus_tests/exc/SB+dmb+rfi-ctrl-svc.c
+++ b/litmus/litmus_tests/exc/SB+dmb+rfi-ctrl-svc.c
@@ -1,0 +1,79 @@
+#include "lib.h"
+
+#define VARS x, y
+#define REGS p0x2, p1x2
+
+static void P0(litmus_test_run* data) {
+  asm volatile (
+    /* initial registers */
+    "mov x0, #1\n\t"
+    "mov x1, %[x]\n\t"
+    "mov x3, %[y]\n\t"
+
+    /* test */
+    "str x0, [x1]\n\t"
+    "dmb st\n\t"
+    "ldr x2, [x3]\n\t"
+
+    /* extract values */
+    "str x2, [%[outp0r2]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+  : "cc", "memory", "x0", "x1", "x2", "x3"
+  );
+}
+
+static void svc_handler1(void) {
+  asm volatile (
+    "ldr x2, [x3]\n\t"
+    "eret\n\t"
+  );
+}
+
+static void P1(litmus_test_run* data) {
+  asm volatile (
+    /* initial registers */
+    "mov x0, #1\n\t"
+    "mov x1, %[y]\n\t"
+    "mov x3, %[x]\n\t"
+
+    /* test */
+    "str x0, [x1]\n\t"
+    "ldr x4, [x1]\n\t"
+    "cbz x4, .lc\n\t"
+    ".lc:\n\t"
+    "svc #0\n\t"
+
+    /* extract values */
+    "str x2, [%[outp1r2]]\n\t"
+  :
+  : ASM_VARS(data, VARS),
+    ASM_REGS(data, REGS)
+    : "cc", "memory", "x0", "x1", "x2", "x3", "x4"
+  );
+}
+
+litmus_test_t SB_dmb_rfictrlsvc = {
+  "SB+dmb+rfi-ctrl-svc",
+  MAKE_THREADS(2),
+  MAKE_VARS(VARS),
+  MAKE_REGS(REGS),
+  INIT_STATE(
+    2,
+    INIT_VAR(x, 0),
+    INIT_VAR(y, 0)
+  ),
+  .thread_sync_handlers = (u32**[]){
+     (u32*[]){NULL, NULL},
+     (u32*[]){(u32*)svc_handler1, NULL},
+  },
+  .interesting_result = (u64[]){
+      /* p0:x2 =*/0,
+      /* p1:x2 =*/0,
+  },
+  .no_sc_results=3,
+  .expected_allowed = (arch_allow_st[]) {
+    {"armv8", OUTCOME_UNKNOWN},
+  }
+};

--- a/litmus/litmus_tests/exc/SB+dmb+rfi-ctrl-svc.c
+++ b/litmus/litmus_tests/exc/SB+dmb+rfi-ctrl-svc.c
@@ -12,7 +12,7 @@ static void P0(litmus_test_run* data) {
 
     /* test */
     "str x0, [x1]\n\t"
-    "dmb st\n\t"
+    "dmb sy\n\t"
     "ldr x2, [x3]\n\t"
 
     /* extract values */

--- a/litmus/litmus_tests/exc/SB+svc-dmb-erets.c
+++ b/litmus/litmus_tests/exc/SB+svc-dmb-erets.c
@@ -1,10 +1,9 @@
-
 #include "lib.h"
 
 #define VARS x, y
 #define REGS p0x2, p1x2
 
-static void svc_handler(void) {
+static void svc_handler0(void) {
   asm volatile (
     "dmb sy\n\t"
     "eret\n\t"
@@ -32,6 +31,14 @@ static void P0(litmus_test_run* data) {
   : "cc", "memory", "x0", "x1", "x2", "x3"
   );
 }
+
+static void svc_handler1(void) {
+  asm volatile (
+    "dmb sy\n\t"
+    "eret\n\t"
+  );
+}
+
 
 static void P1(litmus_test_run* data) {
   asm volatile (
@@ -65,8 +72,8 @@ litmus_test_t SB_svcdmberets = {
     INIT_VAR(y, 0)
   ),
   .thread_sync_handlers = (u32**[]){
-     (u32*[]){(u32*)svc_handler, NULL},
-     (u32*[]){(u32*)svc_handler, NULL},
+     (u32*[]){(u32*)svc_handler0, NULL},
+     (u32*[]){(u32*)svc_handler1, NULL},
   },
   .interesting_result = (u64[]){
       /* p0:x2 =*/0,

--- a/litmus/litmus_tests/exc/SB+svc-erets.c
+++ b/litmus/litmus_tests/exc/SB+svc-erets.c
@@ -1,10 +1,9 @@
-
 #include "lib.h"
 
 #define VARS x, y
 #define REGS p0x2, p1x2
 
-static void svc_handler(void) {
+static void svc_handler0(void) {
   asm volatile (
     "eret\n\t"
   );
@@ -29,6 +28,12 @@ static void P0(litmus_test_run* data) {
   : ASM_VARS(data, VARS),
     ASM_REGS(data, REGS)
   : "cc", "memory", "x0", "x1", "x2", "x3"
+  );
+}
+
+static void svc_handler1(void) {
+  asm volatile (
+    "eret\n\t"
   );
 }
 
@@ -64,8 +69,8 @@ litmus_test_t SB_svcerets = {
     INIT_VAR(y, 0)
   ),
   .thread_sync_handlers = (u32**[]){
-     (u32*[]){(u32*)svc_handler, NULL},
-     (u32*[]){(u32*)svc_handler, NULL},
+     (u32*[]){(u32*)svc_handler0, NULL},
+     (u32*[]){(u32*)svc_handler1, NULL},
   },
   .interesting_result = (u64[]){
       /* p0:x2 =*/0,


### PR DESCRIPTION
Current status:
+ [x] SEA_W_detect  # to (try) directly generate a SyncExtAbt on a STORE
+ [x] SEA_R_detect  # to (try) directly generate a SyncExtAbt on a LOAD
+ [x] MP+dmb+svc
+ [x] MP+dmb+eret
+ [x] MP+dmb+svc-eret
+ [x] MP+dmb+svc-dmb-eret
+ [x] MP+dmb+ctrl-svc
+ [x] MP+dmb+data-svc
+ [x] MP+dmb+ctrl-eret
+ [x] MP+dmb+svc-addreret
+ [x] MP+svc+addr
+ [x] MP+svc-eret+addr
+ [x] MP+svc-dmb-eret+addr
+ [x] MP+svcs
+ [x] MP+erets
+ [x] MP+svc-erets
+ [x] LB+svcs
+ [x] LB+svc-erets FIXME
+ [x] LB+svc-dmb-erets FIXME
+ [x] SB+svc-erets.c FIXME
+ [x] SB+svc-dmb-erets.c FIXME
+ [x] SB+dmb+rfi-ctrl-svc
+ [x] SB+dmb+rfi-ctrl-eret
+ [x] S+svcs
+ [x] S+erets
+ [x] S+svc-erets
+ [x] S+svc-dmb-erets
