### PR TITLE
Add configuration script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
       run: |
         git clone https://github.com/litmus-tests/litmus-tests-armv8a-system-vmsa/
 
+    - name: Configure harness
+      working-directory: rems-project/system-litmus-harness
+      run: |
+        ./utilities/configure.py --clang-format=clang-format-15
+
     - name: Build harness
       working-directory: rems-project/system-litmus-harness
       run: |
@@ -65,7 +70,7 @@ jobs:
     - name: Check for clang-format errors
       working-directory: rems-project/system-litmus-harness
       run: |
-        make fmt-check CLANG-FORMAT=clang-format-15
+        make fmt-check
 
     - name: Run unittests
       working-directory: rems-project/system-litmus-harness

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # bin/ stores the intermediate built files
 /bin/
 
+# auto-generated configuration
+/config.mk
+
 # built executables
 /*qemu_*
 /*kvm_*

--- a/Makefile
+++ b/Makefile
@@ -112,15 +112,25 @@ PREFIXES = kvm qemu qemu_rpi3
 BINTARGETS = litmus unittests
 
 # Compiler and tools options
+-include config.mk
+
+CONFIGURE_CMD ?= ./utilities/configure.py
+
+config.mk: ./utilities/configure.py
+	@echo 'Make: configuration out-of-date, please re-run ./utilities/configure.py script'
+	@echo '      last_invokation: `$(CONFIGURE_CMD)`'
+
+# if no config, or config not fully-specified
+# try guess rest
 KNOWN_PREFIXES = aarch64-linux-gnu- aarch64-none-elf-
-PREFIX = $(word 1, $(foreach PRF,$(KNOWN_PREFIXES),$(if $(shell which $(PRF)gcc),$(PRF),)))
-CC = $(PREFIX)gcc
-LD = $(PREFIX)ld
-OBJCOPY = $(PREFIX)objcopy
-OBJDUMP = $(PREFIX)objdump
-QEMU = qemu-system-aarch64
-GDB = $(PREFIX)gdb
-CLANG-FORMAT = clang-format
+PREFIX ?= $(word 1, $(foreach PRF,$(KNOWN_PREFIXES),$(if $(shell which $(PRF)gcc),$(PRF),)))
+CC ?= $(PREFIX)gcc
+LD ?= $(PREFIX)ld
+OBJCOPY ?= $(PREFIX)objcopy
+OBJDUMP ?= $(PREFIX)objdump
+QEMU ?= qemu-system-aarch64
+GDB ?= $(PREFIX)gdb
+CLANG-FORMAT ?= clang-format
 
 # dependency roots
 # by default we assume rems-project/ repos are siblings to this one
@@ -412,7 +422,7 @@ LITMUS_TARGETS += build-$(t)-$(call stem,$(1))
 # finally put them together into a build-DEVICE target
 # e.g. build-rpi3
 .PHONY: build-$(call stem,$(1))
-build-$(call stem,$(1)): $(foreach t,$(BINTARGETS),$(foreach p,$(PREFIXES),bin/$(call exe_prefix,$(1))$(p)_$(t).exe)) $(foreach t,$(BINTARGETS),$(foreach p,$(PREFIXES),build-$(p)-$(t)-$(call stem,$(1))))
+build-$(call stem,$(1)): $(foreach t,$(BINTARGETS),$(foreach p,$(PREFIXES),bin/$(call exe_prefix,$(1))$(p)_$(t).exe)) $(foreach t,$(BINTARGETS),$(foreach p,$(PREFIXES),build-$(p)-$(t)-$(call stem,$(1)))) config.mk
 LITMUS_TARGETS += build-$(call stem,$(1))
 
 # add a cleanup target

--- a/utilities/configure.py
+++ b/utilities/configure.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+
+import sys
+import shlex
+import pathlib
+import argparse
+import subprocess
+
+HERE = pathlib.Path(__file__).parent
+ROOT = HERE.parent
+
+LINUX_AARCH64_DEFAULTS = {
+    "name": "LINUX_AARCH64_DEFAULTS",
+    "cross_prefix": None,
+    "tools": {
+        "cc": "gcc",
+        "ld": "ld",
+        "objcopy": "objcopy",
+        "objdump": "objdump",
+        "gdb": "gdb",
+        "qemu": "qemu-system-aarch64",
+        "clang_format": "clang-format",
+    },
+}
+
+LINUX_CROSS_DEFAULTS = {
+    "name": "LINUX_CROSS_DEFAULTS",
+    "cross_prefix": "aarch64-linux-gnu-",
+    "tools": {
+        "cross_cc": "gcc",
+        "cross_ld": "ld",
+        "cross_objcopy": "objcopy",
+        "cross_objdump": "objdump",
+        "cross_gdb": "gdb",
+        "qemu": "qemu-system-aarch64",
+        "clang_format": "clang_format",
+    },
+}
+
+PLATFORM_DEFAULTS = {
+    "Linux": {
+        "aarch64": LINUX_AARCH64_DEFAULTS,
+    },
+}
+
+GENERIC_DEFAULT = LINUX_CROSS_DEFAULTS
+
+
+CONFIG = """\
+# auto-generated file, do not edit!
+
+CONFIGURE_CMD = {cmd}
+CROSS-PREFIX = {cross_prefix}
+
+# fully-qualified toolnames
+CC = {cc}
+LD = {ld}
+OBJCOPY = {objcopy}
+OBJDUMP = {objdump}
+QEMU = {qemu}
+GDB = {gdb}
+CLANG-FORMAT = {clang_format}
+"""
+
+
+def get_uname(k):
+    return subprocess.check_output(["uname", k], text=True).strip()
+
+
+def cross_tool(tool):
+    return "cross_" + tool
+
+
+class CommandAction(argparse.Action):
+    def __init__(
+        self, option_strings, dest, default=None, required=False, help=None, cross=False
+    ):
+
+        self._options = option_strings
+        self.cross = cross
+
+        _option_strings = []
+        for option_string in option_strings:
+            _option_strings.append(option_string)
+
+            if cross and option_string.startswith("--"):
+                option_string = "--cross-" + option_string[2:]
+                _option_strings.append(option_string)
+
+        super().__init__(
+            _option_strings,
+            dest,
+            default=default,
+            required=required,
+            help=help,
+        )
+
+    def __call__(self, _parser, namespace, values, option_string=None):
+        if option_string is None:
+            raise ValueError("unexpected positional")
+
+        if option_string.startswith("--cross-"):
+            dest = cross_tool(self.dest)
+        else:
+            dest = self.dest
+
+        setattr(namespace, dest, values)
+
+    def format_usage(self):
+        # format_usage is only used for options which take no value
+        # but all Command actions should take a value
+        raise ValueError("unexpected value")
+
+    def normalise(self, namespace):
+        """turn --cross-prefix=P --cross-tool=X into --tool=XP"""
+        prefix = namespace.cross_prefix
+        cross_tool_suffix = getattr(namespace, cross_tool(self.dest), None)
+        full_tool = getattr(namespace, self.dest, None)
+
+        if self.cross and cross_tool_suffix is not None and full_tool is None:
+            setattr(namespace, self.dest, prefix + cross_tool_suffix)
+
+    def try_fill(self, namespace, defaults):
+        dest = self.dest
+        tool = getattr(namespace, dest, None)
+        default_tool = defaults["tools"].get(dest, None)
+        prefix = defaults["cross_prefix"]
+
+        if self.cross:
+            dest_cross_suffix = cross_tool(dest)
+            tool_cross_suffix = getattr(namespace, dest_cross_suffix, None)
+            default_tool_cross_suffix = defaults["tools"].get(dest_cross_suffix, None)
+
+            if tool is None and tool_cross_suffix is None:
+                if default_tool is not None:
+                    setattr(namespace, dest, default_tool)
+                elif default_tool_cross_suffix is not None:
+                    setattr(
+                        namespace, dest_cross_suffix, prefix + default_tool_cross_suffix
+                    )
+        else:
+            if tool is None and default_tool is not None:
+                setattr(namespace, dest, default_tool)
+
+
+def normalise_args(args):
+    if args.cross_prefix is None:
+        args.cross_prefix = ""
+
+    for action in parser._actions:
+        if isinstance(action, CommandAction):
+            action.normalise(args)
+
+
+def fill_defaults(args):
+    # fill in any already-provided prefixes etc
+    normalise_args(args)
+
+    plat_defaults = PLATFORM_DEFAULTS.get(args.platform, {}).get(args.arch, None)
+
+    if plat_defaults is not None:
+        defaults = plat_defaults
+    else:
+        defaults = GENERIC_DEFAULT
+
+    if not args.cross_prefix and defaults["cross_prefix"]:
+        args.cross_prefix = defaults["cross_prefix"]
+
+    for action in parser._actions:
+        if isinstance(action, CommandAction):
+            action.try_fill(args, defaults)
+
+    # now try fill in any given the defaults
+    normalise_args(args)
+
+
+def write_config(args):
+    cmd = (
+        " ".join(
+            [
+                sys.argv[0],
+                *[shlex.quote(arg) for arg in sys.argv[1:]]
+            ]
+        )
+    )
+
+    with open(ROOT / "config.mk", "w") as f:
+        f.write(CONFIG.format(**vars(args), cmd=cmd))
+
+
+def main(argv):
+    args = parser.parse_args(argv)
+    fill_defaults(args)
+    write_config(args)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--cross-prefix", default=None)
+#
+parser.add_argument("--cc", action=CommandAction, cross=True)
+parser.add_argument("--ld", action=CommandAction, cross=True)
+parser.add_argument("--objcopy", action=CommandAction, cross=True)
+parser.add_argument("--objdump", action=CommandAction, cross=True)
+parser.add_argument("--gdb", action=CommandAction, cross=True)
+#
+parser.add_argument("--qemu", action=CommandAction)
+parser.add_argument("--clang-format", dest="clang_format", action=CommandAction)
+#
+parser.add_argument("--platform", default=get_uname("-s"))
+parser.add_argument("--arch", default=get_uname("-m"))
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Adds a configuration script, to bake in some pre-existing arguments to the Makefile.

This is optional, and the Makefile will continue to guess the cross-compiler prefix and tool names.