### PR TITLE
Uniform BBM on pgtable updates, with appropriate CPU errata workarounds

### DIFF
--- a/inc/arm_features.h
+++ b/inc/arm_features.h
@@ -82,6 +82,13 @@ void arch_read_feature_matrix(struct arch_feature_matrix* m_out);
 u8 arch_feature_version(enum arm_feature id);
 bool arch_has_feature(enum arm_feature id);
 
+/**
+ * struct arm_implementation - Arm MIDR-defined implementation data
+ * @implementor: the implementor code (e.g. 'A' for Arm, etc)
+ * @part: the primary part number (e.g. 0xD0B for Cortex-A76)
+ * @variant: the architecturally-defined variant (e.g. the x from rxpy Arm version)
+ * @revision: the implementation-defined revision (e.g. the y from rxpy Arm version)
+ */
 struct arm_implementation
 {
   char implementor;

--- a/inc/atomics.h
+++ b/inc/atomics.h
@@ -1,0 +1,34 @@
+#ifndef ATOMICS_H
+#define ATOMICS_H
+
+#include "lib.h"
+
+/**
+ * force a single write with release semantics
+ */
+static inline void write_release(volatile u64* loc, u64 val) {
+  /* clang-format off */
+  asm volatile (
+    "stlr %[val],[%[loc]]\n"
+  :
+  : [loc] "r" (loc), [val] "r" (val)
+  : "memory", "cc"
+  );
+  /* clang-format on */
+}
+
+/**
+ * force a single single-copy-atomic write
+ */
+static inline void write_once(volatile u64* loc, u64 val) {
+  /* clang-format off */
+  asm volatile (
+    "str %[val],[%[loc]]\n"
+  :
+  : [loc] "r" (loc), [val] "r" (val)
+  : "memory", "cc"
+  );
+  /* clang-format on */
+}
+
+#endif /* ATOMICS_H */

--- a/inc/cpu_errata.h
+++ b/inc/cpu_errata.h
@@ -1,0 +1,52 @@
+#ifndef CPU_ERRATA_H
+#define CPU_ERRATA_H
+
+#include "lib.h"
+
+/*
+ * We define CPU errata not by their mechanisms or errata numbers,
+ * but by the given workarounds.
+ *
+ * We can then ask e.g. if (cpu_needs_workaround(ERRATA_WORKAROUND_REPEAT_TLBI)) { ... }
+ * agnostic to which CPU precisely requires it.
+ */
+
+/**
+ * enum errata_workaround_label - Names of workarounds for errata.
+ */
+enum errata_workaround_label {
+  /**
+   * ERRATA_WORKAROUND_REPEAT_TLBI - Must repeat TLBI instructions once more
+   */
+  ERRATA_WORKAROUND_REPEAT_TLBI,
+
+  /**
+   * ERRATA_WORKAROUND_ISB_AFTER_PTE_ST - Must insert ISB after the DSB synchronising a store with the TTW
+   *
+   * It seems improbable this affects us, but seems easy enough to avoid.
+   */
+  ERRATA_WORKAROUND_ISB_AFTER_PTE_ST,
+
+  /* end of list */
+  NR_ERRATA,
+};
+
+/**
+ * requires_errata_workaround_map - internal map
+ * look-up table from workaround name to whether the workaround is required for this CPU.
+ */
+extern bool requires_errata_workaround_map[];
+
+/**
+ * cpu_needs_workaround() - Returns whether a workaround is needed
+ */
+static inline bool cpu_needs_workaround(enum errata_workaround_label name) {
+  return requires_errata_workaround_map[name];
+}
+
+/**
+ * initialise_errata_workarounds() - Populate workaround map
+ */
+void initialise_errata_workarounds(void);
+
+#endif /* CPU_ERRATA_H */

--- a/inc/lib.h
+++ b/inc/lib.h
@@ -30,6 +30,8 @@
 #include "stack.h"
 #include "boot.h"
 
+#include "atomics.h"
+
 #include "drivers/driver.h"
 
 const char* version_string(void);

--- a/inc/lib.h
+++ b/inc/lib.h
@@ -29,6 +29,7 @@
 #include "re.h"
 #include "stack.h"
 #include "boot.h"
+#include "cpu_errata.h"
 
 #include "atomics.h"
 

--- a/inc/litmus/litmus_test_ctx.h
+++ b/inc/litmus/litmus_test_ctx.h
@@ -74,6 +74,7 @@ const char* regname_from_idx(test_ctx_t* ctx, var_idx_t idx);
 
 run_count_t run_count_from_idx(test_ctx_t* ctx, run_idx_t idx);
 u64* ptable_from_run(test_ctx_t* ctx, run_idx_t i);
+u64 asid_from_run(test_ctx_t* ctx, run_idx_t i);
 u64 asid_from_run_count(test_ctx_t* ctx, run_count_t r);
 
 /* for loading var_info_t */

--- a/inc/vmm/vmm.h
+++ b/inc/vmm/vmm.h
@@ -190,6 +190,20 @@ void vmm_flush_tlb_vaddr(u64 va);
 void vmm_flush_tlb(void);
 void vmm_flush_tlb_asid(u64 asid);
 
+/* synchronised (with BBM) pgtable updates */
+
+/**
+ * vmm_update_pte() - Write to a pagetable entry.
+ * @pte: location of pagetable entry.
+ * @new_val: new 64-bit descriptor to write to that location.
+ * @sync_kind: what kind of TLB maintenance to perform (by-ALL, by-ASID, by-VA).
+ * @asid_or_va: if sync by-ASID or -VA, the ASID or VA to invalidate for this update.
+ * @force: unconditionally perform TLB maintenance on the location.
+ *
+ * Note: VA should be the full VA, not just the page number.
+ */
+void vmm_update_pte(u64* pte, u64 new_val, sync_type_t sync_kind, u64 asid_or_va, bool force);
+
 /* for debugging and serializing */
 
 /** given a translation table

--- a/inc/vmm/vmm_types.h
+++ b/inc/vmm/vmm_types.h
@@ -22,16 +22,19 @@ typedef struct
 
 typedef struct
 {
+  bool has_src;
+  u64* ptr;
+} pte_src_t;
+
+typedef struct
+{
   union {
     u64 oa;
     u64 table_addr;
   };
 
-  /* src/dest of this desc (if applicable) */
-  union {
-    u64* src;
-    u64* dest;
-  };
+  /* src of this desc (if applicable) */
+  pte_src_t src;
 
   /* parent srcs (if applicable) */
   u64* parents[4];

--- a/inc/vmm/vmm_va_macros.h
+++ b/inc/vmm/vmm_va_macros.h
@@ -3,9 +3,12 @@
 
 #include "lib.h"
 
+#define TTBR0_BADDR_MASK (BITMASK(48) & ~BITMASK(5))
+#define TTBR0_ASID_LO 48
+
 /** build a value suitable for writing to TTBR
  * from the pagetable VA and the desired ASID.
  */
-#define TTBR0(pgtable, asid) (((u64)(pgtable) & (BITMASK(48) ^ 1)) | ((u64)(asid) << 48))
+#define MK_TTBR(pgtable, asid) (((u64)(pgtable)&TTBR0_BADDR_MASK) | ((u64)(asid) << TTBR0_ASID_LO))
 
 #endif /* VMM_VA_MACROS_H */

--- a/lib/arch/cpu_errata.c
+++ b/lib/arch/cpu_errata.c
@@ -1,0 +1,72 @@
+#include "lib.h"
+
+bool requires_errata_workaround_map[NR_ERRATA];
+
+struct arm_implementation_range
+{
+  char implementor;
+  u64 part;
+  u64 min_variant;
+  u64 min_revision;
+  u64 max_variant;
+  u64 max_revision;
+};
+
+bool impl_in_range(struct arm_implementation* impl, struct arm_implementation_range range) {
+  if (impl->implementor != range.implementor)
+    return false;
+
+  if (impl->part != range.part)
+    return false;
+
+  return (
+    (range.min_revision <= impl->revision && impl->revision <= range.max_revision) &&
+    (range.min_variant <= impl->variant && impl->variant <= range.max_variant)
+  );
+}
+
+typedef bool (*matcher_fn)(struct arm_implementation*);
+
+struct errata_workaround
+{
+  char* description;
+  enum errata_workaround_label label;
+  matcher_fn matcher;
+};
+
+static bool matches_a76_r0p0_3(struct arm_implementation* impl) {
+  struct arm_implementation_range a76_r0p0_3 = { 'A', 0xD0B, 0, 0, 0, 3 };
+  return impl_in_range(impl, a76_r0p0_3);
+}
+
+static bool matches_a72_r0p0_3_or_r1p0(struct arm_implementation* impl) {
+  struct arm_implementation_range matches_a72_r0p0_3 = { 'A', 0xD08, 0, 0, 0, 3 };
+  struct arm_implementation_range matches_a72_r1p0 = { 'A', 0xD08, 1, 0, 1, 0 };
+  return impl_in_range(impl, matches_a72_r0p0_3) || impl_in_range(impl, matches_a72_r1p0);
+}
+
+/* clang-format off */
+struct errata_workaround workarounds[] = {
+{
+      .description = "Arm Errata 1286807",
+      .label = ERRATA_WORKAROUND_REPEAT_TLBI,
+      .matcher = matches_a76_r0p0_3,
+    },
+    {
+      .description = "Arm Errata 1387635",
+      .label = ERRATA_WORKAROUND_ISB_AFTER_PTE_ST,
+      .matcher = matches_a72_r0p0_3_or_r1p0,
+    }
+};
+/* clang-format on */
+
+void initialise_errata_workarounds(void) {
+  struct arm_implementation impl;
+  arch_read_implementation(&impl);
+
+  for (int i = 0; i < sizeof(workarounds) / sizeof(workarounds[0]); i++) {
+    struct errata_workaround* workaround = &workarounds[i];
+    if (workaround->matcher(&impl))
+      requires_errata_workaround_map[workaround->label] = true;
+  }
+}

--- a/lib/arch/vmm/vmm.c
+++ b/lib/arch/vmm/vmm.c
@@ -32,6 +32,11 @@ void vmm_update_pte(u64* pte, u64 new_val, sync_type_t sync_kind, u64 asid_or_va
   }
 
   write_release(pte, new_val);
+
+  if (cpu_needs_workaround(ERRATA_WORKAROUND_ISB_AFTER_PTE_ST)) {
+    dsb();
+    isb();
+  }
 }
 
 void vmm_ensure_level(u64* root, int desired_level, u64 va) {

--- a/lib/arch/vmm/vmm_entries.c
+++ b/lib/arch/vmm/vmm_entries.c
@@ -4,8 +4,12 @@
 /* stage 1 attrs */
 attrs_t read_attrs(u64 desc) {
   attrs_t attr = { 0 };
+  /* upper attrs */
   attr.XN = BIT(desc, 54);
-  attr.XN = BIT(desc, 53);
+  attr.PXN = BIT(desc, 53);
+  /* lower attrs */
+  attr.nT = BIT(desc, 16);
+  attr.nG = BIT(desc, 11);
   attr.AF = BIT(desc, 10);
   attr.SH = BIT_SLICE(desc, 9, 8);
   attr.AP = BIT_SLICE(desc, 7, 6);
@@ -58,8 +62,20 @@ desc_t read_desc(u64 entry, int level) {
 }
 
 u64 write_attrs(attrs_t* attrs) {
-  return ((u64)attrs->XN << 54) | ((u64)attrs->PXN << 53) | (attrs->AF << 10) | (attrs->SH << 8) | (attrs->AP << 6) |
-         (attrs->NS << 5) | (attrs->attr << 2);
+  /* clang-format off */
+  u64 enc_attrs = \
+    0                       |
+    ((u64)attrs->XN << 54)  |
+    ((u64)attrs->PXN << 53) |
+    (attrs->nT << 16)       |
+    (attrs->nG << 11)       |
+    (attrs->AF << 10)       |
+    (attrs->SH << 8)        |
+    (attrs->AP << 6)        |
+    (attrs->NS << 5)        |
+    (attrs->attr << 2)      ;
+  /* clang-format on */
+  return enc_attrs;
 }
 
 u64 write_desc(desc_t desc) {
@@ -86,7 +102,19 @@ u64 write_desc(desc_t desc) {
 }
 
 void show_attrs(attrs_t* attrs) {
-  printf("{AF=%d,SH=%p,AP=%p,attr=%p}", attrs->AF, attrs->SH, attrs->AP, attrs->attr);
+  printf(
+    "{XN:%d, PXN:%d, nT:%d, OA[51:48]:%d, nG:%d, AF:%d, SH:%d, AP:%d, NS:%d, attr:%d}",
+    attrs->XN,
+    attrs->PXN,
+    attrs->nT,
+    attrs->OA,
+    attrs->nG,
+    attrs->AF,
+    attrs->SH,
+    attrs->AP,
+    attrs->NS,
+    attrs->attr
+  );
 }
 
 void show_desc(desc_t desc) {

--- a/lib/arch/vmm/vmm_pgtable.c
+++ b/lib/arch/vmm/vmm_pgtable.c
@@ -106,9 +106,9 @@ static void set_block_or_page(u64* root, u64 va, u64 pa, u8 unmap, u64 prot, u64
   desc_t desc = vmm_translation_walk(root, va);
 
   if (!unmap)
-    *desc.src = vmm_make_desc(pa, prot, desc.level);
+    vmm_update_pte(desc.src.ptr, vmm_make_desc(pa, prot, desc.level), SYNC_ALL, 0, false);
   else
-    *desc.src = 0;
+    vmm_update_pte(desc.src.ptr, 0, SYNC_ALL, 0, false);
 }
 
 static void __ptable_set_range(u64* root, u64 pa_start, u64 va_start, u64 va_end, u8 unmap, u64 prot) {

--- a/lib/arch/vmm/vmm_pgtable.c
+++ b/lib/arch/vmm/vmm_pgtable.c
@@ -504,6 +504,15 @@ void vmm_set_id_translation(u64* pgtable) {
 }
 
 static void __vmm_switch_table(u64 new_table, u64 asid) {
+  /* any updates to the pgtables which are still pending
+   * must be done in the current context.
+   * so issue a DSB to ensure that they are complete
+   * before changing the context
+   */
+  dsb();
+  if (cpu_needs_workaround(ERRATA_WORKAROUND_ISB_AFTER_PTE_ST))
+    isb();
+
   write_sysreg(MK_TTBR(new_table, asid), ttbr0_el1);
   isb();
 }

--- a/lib/arch/vmm/vmm_tlbs.c
+++ b/lib/arch/vmm/vmm_tlbs.c
@@ -4,19 +4,36 @@
 void tlbi_va(u64 va) {
   u64 page = va >> 12;
   asm volatile("tlbi vaae1is, %[va]\n" : : [va] "r"(page) : "memory");
+
+  if (cpu_needs_workaround(ERRATA_WORKAROUND_REPEAT_TLBI)) {
+    dsb();
+    asm volatile("tlbi vaae1is, %[va]\n" : : [va] "r"(page) : "memory");
+  }
 }
 
 void tlbi_asid(u64 asid) {
   u64 reg = (asid & 0xff) << 48;
   asm volatile("tlbi aside1is, %[asid]\n" : : [asid] "r"(reg) : "memory");
+
+  if (cpu_needs_workaround(ERRATA_WORKAROUND_REPEAT_TLBI)) {
+    dsb();
+    asm volatile("tlbi aside1is, %[asid]\n" : : [asid] "r"(reg) : "memory");
+  }
 }
 
 void tlbi_all(void) {
   asm volatile("tlbi vmalle1is\n" ::: "memory");
+
+  if (cpu_needs_workaround(ERRATA_WORKAROUND_REPEAT_TLBI)) {
+    dsb();
+    asm volatile("tlbi vmalle1is\n" ::: "memory");
+  }
 }
 
 void vmm_flush_tlb_vaddr(u64 va) {
   dsb();
+  if (cpu_needs_workaround(ERRATA_WORKAROUND_ISB_AFTER_PTE_ST))
+    isb();
   tlbi_va(va);
   dsb();
   isb();
@@ -24,6 +41,8 @@ void vmm_flush_tlb_vaddr(u64 va) {
 
 void vmm_flush_tlb_asid(u64 asid) {
   dsb();
+  if (cpu_needs_workaround(ERRATA_WORKAROUND_ISB_AFTER_PTE_ST))
+    isb();
   tlbi_asid(asid);
   dsb();
   isb();
@@ -31,6 +50,8 @@ void vmm_flush_tlb_asid(u64 asid) {
 
 void vmm_flush_tlb(void) {
   dsb(); // wait for memory actions to complete
+  if (cpu_needs_workaround(ERRATA_WORKAROUND_ISB_AFTER_PTE_ST))
+    isb();
   tlbi_all();
   dsb(); // wait for TLB invalidate to complete
   isb(); // synchronize this hardware thread's translations.

--- a/lib/litmus_test/litmus_test.c
+++ b/lib/litmus_test/litmus_test.c
@@ -223,9 +223,10 @@ static void clean_run_data(
    */
   if (ENABLE_PGTABLE) {
     for (idx = 0, r = batch_start_idx; r < batch_end_idx; r++, idx++) {
+      u64 asid = asid_from_run_count(ctx, r);
       for (var_idx_t v = 0; v < ctx->cfg->no_heap_vars; v++) {
         for (int l = 0; l < 4; l++) {
-          *runs[idx].tt_entries[v][l] = runs[idx].tt_descs[v][l];
+          vmm_update_pte(runs[idx].tt_entries[v][l], runs[idx].tt_descs[v][l], SYNC_ASID, asid, /* force */ true);
         }
       }
     }

--- a/lib/litmus_test/litmus_test.c
+++ b/lib/litmus_test/litmus_test.c
@@ -240,6 +240,9 @@ static void clean_run_data(
 static void clean_tlb_for_batch(test_ctx_t* ctx, run_count_t batch_start_idx, run_count_t batch_end_idx) {
   dsb();
 
+  if (cpu_needs_workaround(ERRATA_WORKAROUND_ISB_AFTER_PTE_ST))
+    isb();
+
   for (run_count_t r = batch_start_idx; r < batch_end_idx; r++) {
     u64 asid = asid_from_run_count(ctx, r);
     tlbi_asid(asid);

--- a/lib/litmus_test/litmus_test.c
+++ b/lib/litmus_test/litmus_test.c
@@ -191,7 +191,7 @@ static void setup_run_data(
 
       if (ENABLE_PGTABLE) {
         for (int lvl = 0; lvl < 4; lvl++) {
-          run->tt_entries[v][lvl] = vmm_pte_at_level(ctx->ptables[asid_from_run_count(ctx, r)], (u64)p, lvl);
+          run->tt_entries[v][lvl] = vmm_pte_at_level(ptable_from_run(ctx, i), (u64)p, lvl);
           run->tt_descs[v][lvl] = *run->tt_entries[v][lvl];
         }
 
@@ -298,6 +298,8 @@ static void prepare_test_contexts(
 /** switch to a particular run's ASID
  */
 static void switch_to_test_context(test_ctx_t* ctx, int vcpu, run_count_t r, exception_handlers_refs_t* handlers) {
+  run_idx_t i = count_to_run_index(ctx, r);
+
   debug("switching to test context for run %ld\n", r);
 
   /* set sysregs to what the test needs
@@ -307,8 +309,8 @@ static void switch_to_test_context(test_ctx_t* ctx, int vcpu, run_count_t r, exc
   _init_sys_state(ctx);
 
   if (ENABLE_PGTABLE && LITMUS_SYNC_TYPE == SYNC_ASID) {
-    u64 asid = asid_from_run_count(ctx, r);
-    u64* ptable = ctx->ptables[asid];
+    u64* ptable = ptable_from_run(ctx, i);
+    u64 asid = asid_from_run(ctx, i);
     debug("switching to ASID %ld, with ptable = %p\n", asid, ptable);
     vmm_switch_ttable_asid(ptable, asid);
   }

--- a/lib/litmus_test/litmus_test_ctx.c
+++ b/lib/litmus_test/litmus_test_ctx.c
@@ -197,6 +197,10 @@ u64 asid_from_run_count(test_ctx_t* ctx, run_count_t r) {
     return 1;
 }
 
+u64 asid_from_run(test_ctx_t* ctx, run_idx_t i) {
+  return asid_from_run_count(ctx, run_count_from_idx(ctx, i));
+}
+
 u64* ptable_from_run(test_ctx_t* ctx, run_idx_t i) {
   run_count_t r = run_count_from_idx(ctx, i);
   u64 asid = asid_from_run_count(ctx, r);

--- a/lib/setup.c
+++ b/lib/setup.c
@@ -247,6 +247,12 @@ begin_el1:
   debug("Running at EL = %p\n", read_sysreg(currentel) >> 2);
   debug("VBAR = %p\n", read_sysreg(vbar_el1));
 
+  /* initialise errata workarounds
+   * *before* we create any pagetables
+   * and on each CPU, producing a map of the union of all workarounds
+   */
+  initialise_errata_workarounds();
+
   if (ENABLE_PGTABLE) {
     u64* vmm_pgtable = vmm_alloc_new_4k_pgtable();
     vmm_pgtables[cpu] = vmm_pgtable;


### PR DESCRIPTION
Yay!

Fixes a number of issues that have plagued the pagetable setup of the harness for a while:
- More conservatively apply BBM, and do so more uniformly.
- Extra barriers around context-switches, to ensure pagetable updates do not float around.
- Handle certain CPU errata around the pagetable code in the harness itself.
- Fix all entries being non-global.

The first three of these are defensive: I have no reason to believe they invalidated previous runs. The latter is fixed by e01b2d8 and affected runs with batched ASIDs.